### PR TITLE
Fix XML tag in a struct in xmlsec package

### DIFF
--- a/xmlsec/encrypt.go
+++ b/xmlsec/encrypt.go
@@ -12,7 +12,7 @@ type EncryptedData struct {
 
 // CipherData represents the <CipherData> tag.
 type CipherData struct {
-	CipherValue string `xml"CipherValue"`
+	CipherValue string `xml:"CipherValue"`
 }
 
 // KeyInfo represents the <KeyInfo> tag.


### PR DESCRIPTION
Fix issue detected by `go vet`:
```
# github.com/goware/saml/xmlsec
./encrypt.go:15: struct field tag `xml"CipherValue"` not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
```